### PR TITLE
…

### DIFF
--- a/2waygeocoderfunction/2waygeocoder.py
+++ b/2waygeocoderfunction/2waygeocoder.py
@@ -26,6 +26,7 @@ def lambda_handler(event, context):
     if status == 200:
         print(f"Successful S3 get_object response. Status - {status}")
         data = pd.read_csv(response.get("Body")).dropna(thresh=2)
+        data = data.rename(columns=str.title)
         columns = data.columns
         Countries = []
         Points = []


### PR DESCRIPTION
The test dataset, `Reverse Geocoding: Miami Housing Dataset`, has the columns capitalized (`LATITUDE`, and `LONGITUDE`), and `2waygeocoderfunction.py` lambda fails to find a match. 

This PR is just changing the headers to `Title` format, which fixes the issue. However, the formatting will not be the same for those columns in the processed files. I don't see an issue with that, but some use-cases may be sensitive to it. In that case, the logic will be to use `Regex` to match all uses of the strings.

If you thin the regex will be the right thing to do, feel free to let me know and I can modify the code to do just that.